### PR TITLE
Remove no_reply from monit and agent calls

### DIFF
--- a/tp/src/plugins/monit/utils.py
+++ b/tp/src/plugins/monit/utils.py
@@ -405,6 +405,6 @@ def update_agent_monit_stats(agent=None, **kwargs):
         .table(AgentCollection)
         .get(agent)
         .update(agent_stats)
-        .run(conn, no_reply=True)
+        .run(conn)
     )
 

--- a/tp/src/plugins/patching/agent_apps/db_calls.py
+++ b/tp/src/plugins/patching/agent_apps/db_calls.py
@@ -297,7 +297,7 @@ def insert_into_agent_apps(customer_name, app, conn=None):
                 r
                 .table(AppCollections.UniqueApplications)
                 .insert(app)
-                .run(conn, no_reply=True)
+                .run(conn)
             )
 
         except Exception as e:


### PR DESCRIPTION
This will fix #212  and #197  on the RethinkDB issue not being able to update the monit stats
